### PR TITLE
feat(ui): pastel mobile-first redesign

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -95,6 +95,7 @@
   color: var(--color-text);
   text-align: right;
   -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 .settings-input::-webkit-outer-spin-button,

--- a/src/App.css
+++ b/src/App.css
@@ -1,174 +1,354 @@
+/* ---------- App shell ---------- */
 .app-container {
-  text-align: center;
-  padding: 20px;
-  font-family: Arial, sans-serif;
-}
-
-.settings-container,
-.timer-container,
-.controls-container {
-  text-align: left;
-}
-
-label {
-  margin-right: 10px;
-}
-
-input {
-  margin: 5px;
-  padding: 5px;
-  width: 50px;
-  text-align: center;
-}
-
-.control-button {
-  padding: 10px 20px;
-  margin: 5px;
-  font-size: 16px;
-  cursor: pointer;
-  border-radius: 8px;
-  border: none;
-  background-color: #007bff;
-  color: white;
-  transition: background-color 0.3s;
-}
-
-.control-button:hover {
-  background-color: #0056b3;
-}
-
-.stop-button {
-  background-color: #dc3545;
-}
-
-.stop-button:hover {
-  background-color: #c82333;
-}
-
-
-.timer-container.resting {
-  border-color: #17a2b8;
-}
-
-/* Countdown overlay */
-.countdown-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.8);
-  color: white;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 48px;
-  z-index: 10;
-}
-
-.settings-container {
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  padding: clamp(12px, 4vw, 24px);
   display: flex;
   flex-direction: column;
-  gap: 15px;
-  max-width: 400px;
-  margin: 0 auto;
+  gap: var(--space-5);
+  text-align: center;
+  animation: fade-in var(--dur-base) var(--ease);
 }
 
+.app-title {
+  margin: var(--space-2) 0 var(--space-1);
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--color-text);
+}
+
+/* ---------- Cards ---------- */
+.card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: clamp(14px, 4vw, 22px);
+  text-align: left;
+  animation: fade-in var(--dur-base) var(--ease);
+}
+
+.card h3 {
+  margin: 0 0 var(--space-3);
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+/* ---------- Settings ---------- */
 .settings-group {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
+}
+
+.settings-group:last-of-type {
+  margin-bottom: var(--space-2);
 }
 
 .settings-group label {
-  flex: 1;
-  text-align: left;
-  font-weight: bold;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-muted);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.settings-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-2);
+}
+
+.settings-fields--single {
+  grid-template-columns: 1fr;
+}
+
+.settings-field {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  background-color: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  transition: border-color var(--dur-fast) var(--ease),
+    background-color var(--dur-fast) var(--ease);
+}
+
+.settings-field:focus-within {
+  border-color: var(--color-accent);
+  background-color: var(--color-surface);
 }
 
 .settings-input {
-  width: 50px;
-  padding: 5px;
-  text-align: center;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  color: var(--color-text);
+  text-align: right;
+  -moz-appearance: textfield;
+}
+
+.settings-input::-webkit-outer-spin-button,
+.settings-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.settings-unit {
+  font-size: var(--font-size-sm);
+  color: var(--color-muted);
 }
 
 .settings-actions {
-  margin-top: 20px;
-}
-
-.settings-button {
-  padding: 8px 12px;
-  margin-right: 10px;
-  font-size: 14px;
-  cursor: pointer;
-  border: 1px solid #007bff;
-  border-radius: 4px;
-  background-color: #007bff;
-  color: white;
-  transition: background-color 0.3s;
-}
-
-.settings-button:hover {
-  background-color: #0056b3;
+  margin-top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
 }
 
 .saved-configs {
-  margin-top: 10px;
-}
-
-.saved-config-button {
-  display: block;
-  margin-top: 5px;
-  padding: 8px 12px;
-  font-size: 12px;
-  cursor: pointer;
-  border: 1px solid #6c757d;
-  border-radius: 4px;
-  background-color: #f8f9fa;
-  color: #343a40;
-  transition: background-color 0.3s;
-}
-
-.saved-config-button:hover {
-  background-color: #e2e6ea;
-}
-
-
-.settings-container,
-.timer-container,
-.controls-container {
-  border: 2px solid #ccc;
-  border-radius: 10px;
-  padding: 15px;
-  margin: 20px auto;
-  max-width: 400px;
-  background-color: #f9f9f9; /* Light background for better visibility */
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* Optional shadow for a subtle 3D effect */
-}
-
-.settings-container h3 {
-  margin-top: 0;
-}
-
-.controls-container {
-  text-align: center;
-}
-
-.timer-container {
   display: flex;
-  justify-content: space-between; /* Space between timer and progress bar */
-  align-items: center;
-  padding: 15px;
-  margin: 10px auto;
-  max-width: 400px;
-  border: 2px solid #ccc;
-  background-color: #f9f9f9;
+  flex-wrap: wrap;
+  gap: var(--space-2);
 }
 
-.timer-container > * {
-  flex: 1;
-  padding: 10px;
+.saved-config-chip {
+  appearance: none;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface-alt);
+  color: var(--color-text);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: background-color var(--dur-fast) var(--ease),
+    border-color var(--dur-fast) var(--ease),
+    transform var(--dur-fast) var(--ease);
+}
+
+.saved-config-chip:hover {
+  background-color: var(--color-accent-soft);
+  border-color: var(--color-accent);
+}
+
+.saved-config-chip:active {
+  transform: scale(0.97);
+}
+
+/* ---------- Buttons ---------- */
+.btn {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 var(--space-5);
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background-color var(--dur-fast) var(--ease),
+    border-color var(--dur-fast) var(--ease),
+    color var(--dur-fast) var(--ease),
+    transform var(--dur-fast) var(--ease),
+    box-shadow var(--dur-fast) var(--ease);
+}
+
+.btn:active {
+  transform: scale(0.98);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn--primary {
+  background-color: var(--color-accent);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+
+.btn--primary:hover {
+  background-color: var(--color-accent-strong);
+}
+
+.btn--secondary {
+  background-color: var(--color-surface-alt);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn--secondary:hover {
+  background-color: var(--color-accent-soft);
+  border-color: var(--color-accent);
+}
+
+.btn--danger {
+  background-color: transparent;
+  color: var(--color-stop-strong);
+  border-color: var(--color-stop);
+}
+
+.btn--danger:hover {
+  background-color: var(--color-stop);
+  color: #fff;
+}
+
+.btn--block {
+  width: 100%;
+}
+
+/* ---------- Timer ---------- */
+.timer-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  padding: clamp(18px, 5vw, 28px);
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-alt) 100%);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  transition: border-color var(--dur-base) var(--ease),
+    box-shadow var(--dur-base) var(--ease);
+}
+
+.timer-card.is-resting {
+  border-color: var(--color-rest);
+  box-shadow: 0 4px 16px rgba(168, 198, 199, 0.35);
+}
+
+.timer-card.is-active {
+  border-color: var(--color-accent);
+  animation: pulse 2.4s var(--ease) infinite;
+}
+
+.timer-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.timer-phase {
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.timer-card.is-resting .timer-phase {
+  color: var(--color-rest);
+}
+
+.timer-card.is-active .timer-phase {
+  color: var(--color-accent-strong);
+}
+
+.timer-display {
+  font-size: var(--font-size-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+  margin: 0;
+  line-height: 1;
+}
+
+.timer-progress {
+  width: clamp(120px, 30vw, 160px);
+  height: clamp(120px, 30vw, 160px);
+  margin-top: var(--space-2);
+}
+
+/* ---------- Controls ---------- */
+.controls-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* ---------- Countdown overlay ---------- */
+.countdown-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--color-overlay);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  animation: fade-in var(--dur-base) var(--ease);
+  padding: var(--space-6);
+}
+
+.countdown-text {
+  margin: 0;
+  font-size: clamp(2.2rem, 9vw, 3.6rem);
+  font-weight: 700;
+  text-align: center;
+  letter-spacing: -0.01em;
+}
+
+/* ---------- Animations ---------- */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    box-shadow: 0 4px 12px rgba(126, 168, 141, 0.18);
+  }
+  50% {
+    box-shadow: 0 4px 22px rgba(126, 168, 141, 0.38);
+  }
+}
+
+/* ---------- Tablet+ breakpoint ---------- */
+@media (min-width: 640px) {
+  .app-container {
+    max-width: 560px;
+    gap: var(--space-6);
+  }
+
+  .timer-card {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    text-align: left;
+  }
+
+  .timer-stack {
+    align-items: flex-start;
+  }
+
+  .controls-row {
+    flex-direction: row;
+  }
+
+  .controls-row .btn {
+    flex: 1;
+  }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import Settings from './components/Settings';
 import Timer from './components/Timer';
 import Controls from './components/Controls';
-import ProgressBar from './components/ProgressBar';
 import { useTimer } from './hooks/useTimer';
 import { DEFAULTS } from './config/defaults';
 import './App.css';
@@ -26,46 +25,34 @@ function App() {
 
   return (
     <div className="app-container">
-      <h1>Interval Timer App</h1>
+      <h1 className="app-title">Interval Timer</h1>
       {isRunning && countdown > 0 ? (
-        <div className="countdown-overlay">
-          <h2>Starting in {countdown}...</h2>
+        <div className="countdown-overlay" role="status" aria-live="polite">
+          <h2 className="countdown-text">Starting in {countdown}…</h2>
         </div>
       ) : (
         <>
-          <div className="settings-container">
-            <Settings
-              intervalDuration={intervalDuration}
-              setIntervalDuration={setIntervalDuration}
-              restDuration={restDuration}
-              setRestDuration={setRestDuration}
-              totalIntervals={totalIntervals}
-              setTotalIntervals={setTotalIntervals}
-            />
-          </div>
-          <div className="timer-container">
-            <Timer
-              timeLeft={timeLeft}
-              isResting={isResting}
-              currentInterval={currentInterval}
-              totalIntervals={totalIntervals}
-            />
-            <div style={{ width: '100px', height: '100px' }}>
-              <ProgressBar
-                totalIntervals={totalIntervals}
-                currentInterval={currentInterval}
-                isResting={isResting}
-              />
-            </div>
-          </div>
-          <div className="controls-container">
-            <Controls
-              isRunning={isRunning}
-              isPaused={isPaused}
-              onStartPause={isRunning ? togglePause : start}
-              onStop={stop}
-            />
-          </div>
+          <Settings
+            intervalDuration={intervalDuration}
+            setIntervalDuration={setIntervalDuration}
+            restDuration={restDuration}
+            setRestDuration={setRestDuration}
+            totalIntervals={totalIntervals}
+            setTotalIntervals={setTotalIntervals}
+          />
+          <Timer
+            timeLeft={timeLeft}
+            isResting={isResting}
+            isRunning={isRunning}
+            currentInterval={currentInterval}
+            totalIntervals={totalIntervals}
+          />
+          <Controls
+            isRunning={isRunning}
+            isPaused={isPaused}
+            onStartPause={isRunning ? togglePause : start}
+            onStop={stop}
+          />
         </>
       )}
     </div>

--- a/src/components/Controls.js
+++ b/src/components/Controls.js
@@ -1,12 +1,23 @@
 import React from 'react';
 
 function Controls({ isRunning, isPaused, onStartPause, onStop }) {
+  const primaryLabel = isRunning ? (isPaused ? 'Continue' : 'Pause') : 'Start';
+
   return (
-    <div className="controls-container">
-      <button onClick={onStartPause} className="control-button">
-        {isRunning ? (isPaused ? 'Continue' : 'Pause') : 'Start'}
+    <div className="controls-row">
+      <button
+        type="button"
+        onClick={onStartPause}
+        className="btn btn--primary btn--block"
+      >
+        {primaryLabel}
       </button>
-      <button onClick={onStop} className="control-button stop-button">
+      <button
+        type="button"
+        onClick={onStop}
+        className="btn btn--danger btn--block"
+        disabled={!isRunning}
+      >
         Stop
       </button>
     </div>

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -7,17 +7,17 @@ function ProgressBar({ totalIntervals, currentInterval, isResting }) {
   const percentage = calculateProgress({ currentInterval, totalIntervals });
 
   return (
-    <div style={{ width: 100, height: 100, margin: 'auto' }}>
-      <CircularProgressbar
-        value={percentage}
-        text={`${Math.round(percentage)}%`}
-        styles={buildStyles({
-          pathColor: isResting ? 'azure' : 'cerulean',
-          trailColor: 'navy',
-          textSize: '15px',
-        })}
-      />
-    </div>
+    <CircularProgressbar
+      value={percentage}
+      text={`${Math.round(percentage)}%`}
+      styles={buildStyles({
+        pathColor: isResting ? '#a8c6c7' : '#7ea88d',
+        trailColor: '#f2e9dc',
+        textColor: '#3f3428',
+        textSize: '20px',
+        pathTransitionDuration: 0.4,
+      })}
+    />
   );
 }
 

--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -26,84 +26,97 @@ function Settings({
     setTotalIntervals(config.totalIntervals);
   };
 
-  return (
-    <div className="settings-container">
-      <h3>Settings</h3>
-      <div className="settings-group">
-        <label>Interval Duration: </label>
+  const renderDurationFields = (id, value, setter) => (
+    <div className="settings-fields">
+      <div className="settings-field">
         <input
+          id={`${id}-min`}
           type="number"
-          name="minutes"
-          value={intervalDuration.minutes}
-          onChange={(e) =>
-            setIntervalDuration((prev) => ({ ...prev, minutes: parseInt(e.target.value, 10) || 0 }))
-          }
           min="0"
-          className="settings-input"
-        />{' '}
-        min
-        <input
-          type="number"
-          name="seconds"
-          value={intervalDuration.seconds}
+          value={value.minutes}
           onChange={(e) =>
-            setIntervalDuration((prev) => ({ ...prev, seconds: parseInt(e.target.value, 10) || 0 }))
+            setter((prev) => ({ ...prev, minutes: parseInt(e.target.value, 10) || 0 }))
           }
-          min="0"
           className="settings-input"
-        />{' '}
-        sec
-      </div>
-      <div className="settings-group">
-        <label>Rest Duration: </label>
-        <input
-          type="number"
-          name="minutes"
-          value={restDuration.minutes}
-          onChange={(e) =>
-            setRestDuration((prev) => ({ ...prev, minutes: parseInt(e.target.value, 10) || 0 }))
-          }
-          min="0"
-          className="settings-input"
-        />{' '}
-        min
-        <input
-          type="number"
-          name="seconds"
-          value={restDuration.seconds}
-          onChange={(e) =>
-            setRestDuration((prev) => ({ ...prev, seconds: parseInt(e.target.value, 10) || 0 }))
-          }
-          min="0"
-          className="settings-input"
-        />{' '}
-        sec
-      </div>
-      <div className="settings-group">
-        <label>Total Intervals: </label>
-        <input
-          type="number"
-          value={totalIntervals}
-          onChange={(e) => setTotalIntervals(parseInt(e.target.value, 10) || 0)}
-          min="1"
-          className="settings-input"
+          aria-label={`${id} minutes`}
         />
+        <span className="settings-unit">min</span>
       </div>
-      <div className="settings-actions">
-        <button onClick={handleSave} className="settings-button">Save Configuration</button>
-        <div className="saved-configs">
-          {savedConfigs.map((config, index) => (
-            <button
-              key={index}
-              onClick={() => handleLoad(config)}
-              className="saved-config-button"
-            >
-              Config {index + 1}: {config.intervalDuration.minutes}m {config.intervalDuration.seconds}s / {config.restDuration.minutes}m {config.restDuration.seconds}s / {config.totalIntervals} intervals
-            </button>
-          ))}
-        </div>
+      <div className="settings-field">
+        <input
+          id={`${id}-sec`}
+          type="number"
+          min="0"
+          value={value.seconds}
+          onChange={(e) =>
+            setter((prev) => ({ ...prev, seconds: parseInt(e.target.value, 10) || 0 }))
+          }
+          className="settings-input"
+          aria-label={`${id} seconds`}
+        />
+        <span className="settings-unit">sec</span>
       </div>
     </div>
+  );
+
+  return (
+    <section className="card">
+      <h3>Settings</h3>
+
+      <div className="settings-group">
+        <label htmlFor="interval-min">Interval duration</label>
+        {renderDurationFields('interval', intervalDuration, setIntervalDuration)}
+      </div>
+
+      <div className="settings-group">
+        <label htmlFor="rest-min">Rest duration</label>
+        {renderDurationFields('rest', restDuration, setRestDuration)}
+      </div>
+
+      <div className="settings-group">
+        <label htmlFor="total-intervals">Total intervals</label>
+        <div className="settings-fields settings-fields--single">
+          <div className="settings-field">
+            <input
+              id="total-intervals"
+              type="number"
+              min="1"
+              value={totalIntervals}
+              onChange={(e) => setTotalIntervals(parseInt(e.target.value, 10) || 0)}
+              className="settings-input"
+              aria-label="Total intervals"
+            />
+            <span className="settings-unit">rounds</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="settings-actions">
+        <button
+          type="button"
+          onClick={handleSave}
+          className="btn btn--secondary btn--block"
+        >
+          Save configuration
+        </button>
+        {savedConfigs.length > 0 && (
+          <div className="saved-configs">
+            {savedConfigs.map((config, index) => (
+              <button
+                key={index}
+                type="button"
+                onClick={() => handleLoad(config)}
+                className="saved-config-chip"
+              >
+                {config.intervalDuration.minutes}m {config.intervalDuration.seconds}s ·{' '}
+                {config.restDuration.minutes}m {config.restDuration.seconds}s ·{' '}
+                {config.totalIntervals}×
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
   );
 }
 

--- a/src/components/Timer.js
+++ b/src/components/Timer.js
@@ -1,12 +1,29 @@
 import React from 'react';
 import { formatTime } from '../utils/timerEngine';
+import ProgressBar from './ProgressBar';
 
-function Timer({ timeLeft, isResting, currentInterval, totalIntervals }) {
+function Timer({ timeLeft, isResting, isRunning, currentInterval, totalIntervals }) {
+  const phaseClass = isResting ? 'is-resting' : isRunning ? 'is-active' : '';
+  const phaseLabel = isResting
+    ? 'Resting'
+    : isRunning
+      ? `Interval ${currentInterval} of ${totalIntervals}`
+      : 'Ready';
+
   return (
-    <div className={`timer-container ${isResting ? 'resting' : 'active'}`}>
-      <h2>{isResting ? 'Resting' : `Interval ${currentInterval} of ${totalIntervals}`}</h2>
-      <p>{formatTime(timeLeft)}</p>
-    </div>
+    <section className={`timer-card ${phaseClass}`.trim()} aria-live="polite">
+      <div className="timer-stack">
+        <span className="timer-phase">{phaseLabel}</span>
+        <p className="timer-display">{formatTime(timeLeft)}</p>
+      </div>
+      <div className="timer-progress">
+        <ProgressBar
+          totalIntervals={totalIntervals}
+          currentInterval={currentInterval}
+          isResting={isResting}
+        />
+      </div>
+    </section>
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,108 @@
+:root {
+  /* Color palette — calm creamy pastel */
+  --color-bg: #f7f2e8;
+  --color-surface: #fffaf2;
+  --color-surface-alt: #f2e9dc;
+  --color-text: #3f3428;
+  --color-muted: #7a6b5a;
+  --color-border: #e8ddcd;
+
+  --color-accent: #7ea88d;
+  --color-accent-soft: #c6dccd;
+  --color-accent-strong: #6b9079;
+
+  --color-rest: #a8c6c7;
+  --color-rest-soft: #d6e6e6;
+
+  --color-stop: #d68a78;
+  --color-stop-strong: #b9715f;
+
+  --color-shadow: rgba(78, 62, 45, 0.10);
+  --color-shadow-strong: rgba(78, 62, 45, 0.16);
+  --color-overlay: rgba(63, 52, 40, 0.78);
+
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-pill: 999px;
+
+  --shadow-sm: 0 1px 2px var(--color-shadow);
+  --shadow-md: 0 4px 12px var(--color-shadow);
+  --shadow-lg: 0 12px 28px var(--color-shadow-strong);
+
+  --font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  --font-size-xs: clamp(0.75rem, 1.6vw, 0.85rem);
+  --font-size-sm: clamp(0.85rem, 2vw, 0.95rem);
+  --font-size-md: clamp(0.95rem, 2.5vw, 1.05rem);
+  --font-size-lg: clamp(1.1rem, 3vw, 1.35rem);
+  --font-size-xl: clamp(1.4rem, 4.5vw, 1.9rem);
+  --font-size-display: clamp(2.4rem, 12vw, 4rem);
+
+  --ease: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --dur-fast: 140ms;
+  --dur-base: 220ms;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  padding: 0;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+}
+
+#root {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+}
+
+button {
+  font-family: inherit;
+}
+
+input {
+  font-family: inherit;
+  color: inherit;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }


### PR DESCRIPTION
Implements a modern calm pastel UI: design tokens (color/spacing/typography), mobile-first responsive layout via clamp() and a single 640px breakpoint, card-based sections, pill-style touch-friendly buttons (48px min), chip-style saved configs, fluid timer display, fixed invalid progress bar colors, removed nested timer wrapper. No timer logic/persistence changes; tests/lint pass.